### PR TITLE
Add applications Kustomization and restore otel-demo network policies

### DIFF
--- a/clusters/homelab/applications.yaml
+++ b/clusters/homelab/applications.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: applications
+  namespace: flux-system
+spec:
+  interval: 10m
+  dependsOn:
+    - name: monitoring
+    - name: sources
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/applications
+  prune: true
+  wait: true

--- a/k8s/core/security/otel-demo-network-policies.yaml
+++ b/k8s/core/security/otel-demo-network-policies.yaml
@@ -1,0 +1,133 @@
+---
+# Default deny all traffic in otel-demo namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: otel-demo
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+# Allow OpenTelemetry Collector to send traces to Tempo
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-otel-collector
+  namespace: otel-demo
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Accept traces from demo services
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: otel-demo
+    ports:
+    - protocol: TCP
+      port: 4317  # OTLP gRPC
+    - protocol: TCP
+      port: 4318  # OTLP HTTP
+    - protocol: TCP
+      port: 9411  # Zipkin
+    - protocol: TCP
+      port: 14250 # Jaeger gRPC
+    - protocol: TCP
+      port: 14268 # Jaeger HTTP
+  egress:
+  # Send traces to Tempo
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: tempo
+    ports:
+    - protocol: TCP
+      port: 4317  # OTLP gRPC
+    - protocol: TCP
+      port: 4318  # OTLP HTTP
+  # DNS
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+---
+# Allow demo services to communicate with each other
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-demo-services
+  namespace: otel-demo
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: otel-demo
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Accept traffic from other demo services
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: otel-demo
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+  egress:
+  # Allow communication to other demo services
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: otel-demo
+  # Allow sending traces to collector
+  - to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/component: opentelemetry-collector
+    ports:
+    - protocol: TCP
+      port: 4317
+    - protocol: TCP
+      port: 4318
+  # DNS
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+---
+# Allow frontend to be accessed from ingress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-frontend
+  namespace: otel-demo
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: frontend
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: otel-demo


### PR DESCRIPTION
This completes the observability demo setup:

1. Added applications Kustomization to deploy otel-demo HelmRelease
   - Path: clusters/homelab/applications.yaml
   - Depends on: monitoring, sources

2. Restored otel-demo network policies (now safe with namespace existing)
   - Allows OTel Collector → Tempo communication
   - Allows demo services intercommunication
   - Secures with default-deny-all policy

The namespace ordering issue is resolved because:
- HelmRelease creates namespace first (via applications Kustomization)
- Network policies are applied after (via core-security Kustomization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)