### PR TITLE
Fix HelmRepository API version for Flux v2.8.3 compatibility

### DIFF
--- a/infrastructure/sources/ingress-nginx.yaml
+++ b/infrastructure/sources/ingress-nginx.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: ingress-nginx

--- a/infrastructure/sources/jetstack.yaml
+++ b/infrastructure/sources/jetstack.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: jetstack

--- a/infrastructure/sources/metallb.yaml
+++ b/infrastructure/sources/metallb.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: metallb

--- a/infrastructure/sources/nfs-provisioner.yaml
+++ b/infrastructure/sources/nfs-provisioner.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: nfs-subdir-external-provisioner

--- a/infrastructure/sources/prometheus-community.yaml
+++ b/infrastructure/sources/prometheus-community.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus-community


### PR DESCRIPTION
Update all HelmRepository sources from deprecated
source.toolkit.fluxcd.io/v1beta2 to source.toolkit.fluxcd.io/v1. Flux v2.8.3 removed v1beta2 support, causing the sources Kustomization to fail dry-run and cascading failures across all dependent Kustomizations.