### PR TITLE
fix(monitoring): restore Prometheus scraping (DNS + API egress)

### DIFF
--- a/k8s/core/security/network-policies.yaml
+++ b/k8s/core/security/network-policies.yaml
@@ -33,6 +33,23 @@ spec:
     - protocol: TCP
       port: 9090
   egress:
+  # Kubernetes API — REQUIRED for service discovery. Without it the scrape
+  # ports below are moot: SD returns zero targets, so Prometheus scrapes
+  # nothing (not even itself) and every existing alert goes silently blind.
+  # Same port-only pattern as allow-grafana / allow-kube-state-metrics.
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+  # DNS — resolve scrape-target and API service names.
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
   - to:
     - namespaceSelector: {}
     ports:


### PR DESCRIPTION
## The problem — monitoring is silently blind

Prometheus has scraped **nothing** (not even itself) for at least 24h. Diagnosed live:

- 15 scrape jobs configured → **0 active / 0 dropped targets**
- TSDB head = 6 series (all recording-rule/`ALERTS` output; no scraped data)
- `up{}` and `node_filesystem{}` return no data across a 24h range
- the pod can't resolve `kubernetes.default.svc` (`bad address`)

Every existing alert (`NfsSpaceLow`, `PVCAlmostFull`, `PodCrashLooping`, …) has therefore been unable to fire. It stayed silent because target-down alerts route to the `null` receiver.

## Root cause

`allow-prometheus` granted egress to the **scrape ports** (9100 / 8080 / 10250) but **not** to the **Kubernetes API** (443/6443) or **DNS** (53). Prometheus discovers targets via the API — with that egress blocked, service discovery returns zero targets, so the allowed scrape ports are never even used.

This is the **same incomplete-egress bug already documented in this file** on `allow-kube-state-metrics` and `allow-alertmanager`.

## Fix

Mirror the `allow-grafana` pattern — add port-only API egress (443/6443) and DNS (53 TCP/UDP), keeping the existing scrape-port rule.

## Verification plan (post-merge)

Flux syncs → within minutes:
- `/api/v1/targets` active targets go from 0 → ~14, health=up
- `count(up)` and `node_filesystem_size_bytes{mountpoint="/mnt/media"}` return data

Jellyfin-specific alerts (unmount / restarts / memory) follow in a second PR **after** metrics are confirmed flowing — so the `absent()`-based unmount alert has real data behind it and can't false-fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)