### PR TITLE
feat(monitoring): Jellyfin alerts + restore node-exporter/kubelet scraping

### DIFF
--- a/infrastructure/media/jellyfin.yaml
+++ b/infrastructure/media/jellyfin.yaml
@@ -96,13 +96,13 @@ spec:
         memory: 2560Mi
 
     metrics:
-      enabled: true
-      serviceMonitor:
-        enabled: true
-        # Prometheus selects ServiceMonitors by this label (see the live
-        # Prometheus spec.serviceMonitorSelector) — without it, no scrape.
-        labels:
-          release: prometheus-stack
+      # Disabled: Jellyfin only serves /metrics when its app-level
+      # EnableMetrics=true (default false), so this ServiceMonitor was scraping
+      # a 404 target 24/7. Jellyfin's native exporter is low-value anyway
+      # (HTTP/kestrel/.NET counters — no stream or transcode metrics), so it's
+      # not worth the app config + restart. Alerting for Jellyfin comes from
+      # node-exporter / cAdvisor / kube-state-metrics instead (jellyfin-alerts).
+      enabled: false
 
   # The chart offers no mountPropagation on the media mount. HostToContainer
   # makes a host-side remount (HDD replug + mount -a) reach a running pod

--- a/infrastructure/monitoring/jellyfin-alerts.yaml
+++ b/infrastructure/monitoring/jellyfin-alerts.yaml
@@ -1,0 +1,56 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: jellyfin-alerts
+  namespace: monitoring
+  labels:
+    # Selected by the Prometheus rule selector (same label as homelab-alerts).
+    release: prometheus-stack
+spec:
+  groups:
+    - name: jellyfin
+      rules:
+        # The media HDD uses `nofail`, so if it unplugs/unmounts the node stays
+        # up and the running Jellyfin pod keeps a dead mount — the initContainer
+        # only guards at startup. When the mount vanishes, node-exporter stops
+        # reporting the filesystem and this series disappears. `absent()` then
+        # fires. (Matches on mountpoint only — robust to an ntfs/ntfs3 driver
+        # change on remount.) `for: 10m` also debounces Prometheus restarts.
+        - alert: JellyfinMediaMountGone
+          expr: absent(node_filesystem_size_bytes{mountpoint="/mnt/media"})
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Jellyfin media HDD not mounted on the node"
+            description: "node-exporter reports no filesystem at /mnt/media for 10m — the external media drive is unmounted/unplugged. Jellyfin will serve an empty or stale library. Check the HDD and `scripts/common/mount-media-hdd.sh`."
+
+        # Generic PodCrashLooping needs sustained looping; a single OOMKill or
+        # one-off restart mid-stream wouldn't trip it. This catches that.
+        - alert: JellyfinRestarted
+          expr: increase(kube_pod_container_status_restarts_total{namespace="media",container="jellyfin"}[1h]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Jellyfin container restarted"
+            description: "Jellyfin restarted {{ $value | printf \"%.0f\" }} time(s) in the last hour (namespace media). Likely an OOMKill (2560Mi limit) or crash — check `kubectl describe pod` and last-state reason."
+
+        # Working set approaching the 2560Mi limit -> OOMKill risk mid-stream.
+        # Join memory usage (cAdvisor) to the limit (kube-state-metrics) per pod.
+        - alert: JellyfinMemoryNearLimit
+          expr: |
+            max by (namespace, pod) (
+              container_memory_working_set_bytes{namespace="media", container="jellyfin"}
+            )
+            / on (namespace, pod)
+            max by (namespace, pod) (
+              kube_pod_container_resource_limits{namespace="media", container="jellyfin", resource="memory"}
+            )
+            > 0.9
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Jellyfin memory near its limit"
+            description: "Jellyfin working set is above 90% of its 2560Mi limit for 10m (current: {{ $value | humanizePercentage }}). Risk of OOMKill during playback — check for a software transcode (HEVC on this CPU) or a metadata scan."

--- a/k8s/core/security/network-policies.yaml
+++ b/k8s/core/security/network-policies.yaml
@@ -59,6 +59,20 @@ spec:
       port: 8080  # kube-state-metrics
     - protocol: TCP
       port: 10250 # Kubelet
+  # node-exporter (hostNetwork) and the kubelet/cAdvisor endpoint live on the
+  # NODE IP, not a pod IP — a namespaceSelector can never match them, so the
+  # rule above is a no-op for those two targets and they stay down (no
+  # node_filesystem / container_* metrics). An ipBlock to the node is required.
+  # Node IP is ${NODE_IP} in cluster-config; static here since this file isn't
+  # var-substituted. Update both if the node IP ever changes.
+  - to:
+    - ipBlock:
+        cidr: 192.168.100.98/32
+    ports:
+    - protocol: TCP
+      port: 9100   # node-exporter (hostNetwork)
+    - protocol: TCP
+      port: 10250  # kubelet / cAdvisor
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
Follow-up to #25. That PR restored DNS+API egress so service discovery runs (0 → 8 targets), but **node-exporter and kubelet/cAdvisor are still down**, so `node_filesystem` and `container_*` metrics never arrive — leaving the memory + unmount alerts (and the generic node/PVC alerts) blind. This finishes the job.

## 1. NetworkPolicy — node-IP egress (the remaining scrape gap)
node-exporter (`hostNetwork`) and the kubelet endpoint both live on the **node IP** `192.168.100.98`, which a `namespaceSelector` can never match — so ports 9100/10250 were "allowed" but unreachable. Adds an `ipBlock` egress to the node IP for those ports.

Expected post-merge: targets 8 → ~10 up (node-exporter + kubelet green), and `node_filesystem` / `container_memory` start reporting. This also revives the pre-existing `NfsSpaceLow` / `DiskSpaceLow` / `HighCPU/Mem` / `PVCAlmostFull` alerts, which were silently blind for the same reason.

## 2. `jellyfin-alerts.yaml` (new PrometheusRule)
Auto-selected via `release=prometheus-stack`; `severity: warning|critical` auto-routes to Telegram (no routing changes).

| Alert | Sev | Fires when |
|---|---|---|
| `JellyfinMediaMountGone` | critical | `absent(node_filesystem{mountpoint="/mnt/media"})` 10m — the `nofail` HDD unmounted; invisible to the startup-only initContainer |
| `JellyfinRestarted` | warning | a restart in the last 1h — catches a one-off OOMKill that `PodCrashLooping` (sustained-loop) misses |
| `JellyfinMemoryNearLimit` | warning | working set >90% of the 2560Mi cap for 10m |

## 3. `jellyfin.yaml` — `metrics.enabled: false`
Jellyfin's app-level `EnableMetrics` is off, so the ServiceMonitor was scraping a **404 target 24/7**. Its native exporter is low-value (HTTP/kestrel/.NET only — no stream/transcode metrics), so alerts source from node-exporter/cAdvisor/KSM instead.

## Validation
- All three PromQL exprs parse (`/api/v1/query` returns `success`).
- `PrometheusRule` passes `kubectl apply --dry-run=server`.

## Post-merge verification (I'll run it)
1. node-exporter + kubelet targets go up; `node_filesystem{mountpoint="/mnt/media"}` and `container_memory_working_set_bytes{...jellyfin}` return data.
2. The 3 rules load in `/api/v1/rules`, state `inactive` (not firing) — confirming no false-positive on the `absent()` rule now that node data flows.
3. `jellyfin` scrape target is gone (no more 404).

> ⚠️ Scope note: this expands the originally-scoped "alerts + disable scrape" with the node-IP NetworkPolicy fix, because without it two of the three alerts have no data. Still-blind targets **grafana / alertmanager / coredns / operator** (metrics ports 3000/9093/9153 not in the allowlist) are a separate same-class follow-up, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)