### PR TITLE
fix(monitoring): restore grafana/alertmanager/coredns/operator scraping

### DIFF
--- a/k8s/core/security/network-policies.yaml
+++ b/k8s/core/security/network-policies.yaml
@@ -56,9 +56,15 @@ spec:
     - protocol: TCP
       port: 9100  # Node exporter
     - protocol: TCP
-      port: 8080  # kube-state-metrics
+      port: 8080  # kube-state-metrics + prometheus-operator + alertmanager reloader
     - protocol: TCP
       port: 10250 # Kubelet
+    - protocol: TCP
+      port: 3000  # Grafana
+    - protocol: TCP
+      port: 9093  # Alertmanager
+    - protocol: TCP
+      port: 9153  # CoreDNS (kube-system)
   # node-exporter (hostNetwork) and the kubelet/cAdvisor endpoint live on the
   # NODE IP, not a pod IP — a namespaceSelector can never match them, so the
   # rule above is a no-op for those two targets and they stay down (no
@@ -133,6 +139,10 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: ingress-nginx
+    # Prometheus scrapes Grafana's own /metrics on 3000 (self-health).
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
     ports:
     - protocol: TCP
       port: 3000
@@ -202,6 +212,9 @@ spec:
     ports:
     - protocol: TCP
       port: 9093
+    # Prometheus also scrapes the config-reloader sidecar's /metrics on 8080.
+    - protocol: TCP
+      port: 8080
   egress:
   - to:
     - podSelector:
@@ -321,3 +334,45 @@ spec:
       port: 3100
   egress:
   - {}  # Allow all egress for storage access
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-operator
+  namespace: monitoring
+spec:
+  # Was previously created out-of-band (not in this repo) as an Egress-only
+  # policy, so default-deny-all still blocked ALL ingress to the operator —
+  # Prometheus couldn't scrape its /metrics (8080) and the target stayed down.
+  # Now Git-managed: same egress (API + DNS) it had, plus the missing ingress.
+  # NB: the operator carries the legacy bare `app` label (unlike the stack's
+  # other pods) — this selector is correct for it.
+  podSelector:
+    matchLabels:
+      app: kube-prometheus-stack-operator
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - protocol: TCP
+      port: 8080  # operator /metrics
+  egress:
+  # Manages CRs via the Kubernetes API.
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 443
+  # DNS.
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53


### PR DESCRIPTION
Third and final follow-up to #25 / #26 — brings the last four blind scrape targets green so the whole monitoring surface is up.

All four are pod-IP targets, down due to a mix of missing **egress** (Prometheus side) and missing **ingress** (target side, blocked by `default-deny-all`). Diagnosed from live scrape errors (`dial tcp … connect: no route/refused`):

| Target | Port | Egress fix | Ingress fix |
|---|---|---|---|
| grafana | 3000 | add 3000 | `allow-grafana`: +prometheus→3000 |
| alertmanager | 9093 | add 9093 | (already allowed) |
| alertmanager (reloader) | 8080 | already allowed | `allow-alertmanager`: +prometheus→8080 |
| coredns | 9153 | add 9153 | none (kube-system has no NetworkPolicy) |
| operator | 8080 | already allowed | `allow-prometheus-operator` (see below) |

### `allow-prometheus-operator` drift
This policy existed **live but not in the repo** — created out-of-band as **Egress-only**, so `default-deny-all` still blocked all ingress to the operator and Prometheus couldn't scrape it. Now Git-managed: preserves its original egress (API 443 + DNS) and adds the missing `prometheus → 8080` ingress. Flux adopts the live resource on apply, fixing the drift.

### Validation
`kubectl apply --dry-run=server` applies clean for all policies.

### Post-merge verification (I'll run it)
Targets 6 → ~10 up; `grafana`, `alertmanager` (×2), `coredns`, `operator` all `health: up`. This closes out the monitoring blackout that #25 first uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)