### PR TITLE
security(nfs): restrict NFS exports from * to node + pod CIDR

### DIFF
--- a/scripts/common/secure-nfs.sh
+++ b/scripts/common/secure-nfs.sh
@@ -22,14 +22,29 @@ for dir in prometheus grafana alertmanager-0 alertmanager-1; do
     echo "Secured /data/$dir"
 done
 
-# Update exports file with more secure options
-cat > /etc/exports <<EOF
-/data           *(rw,sync,no_subtree_check,no_root_squash)
-/data/prometheus *(rw,sync,no_subtree_check,all_squash,anonuid=65534,anongid=65534)
-/data/grafana    *(rw,sync,no_subtree_check,all_squash,anonuid=65534,anongid=65534)
-/data/alertmanager-0 *(rw,sync,no_subtree_check,all_squash,anonuid=65534,anongid=65534)
-/data/alertmanager-1 *(rw,sync,no_subtree_check,all_squash,anonuid=65534,anongid=65534)
-EOF
+# Allowed NFS clients. Was "*" (ANY LAN host could mount /data as root over the
+# WiFi). NFS is only consumed in-cluster — restrict to the k3s node + pod CIDR.
+NFS_ALLOWED="${NFS_ALLOWED:-192.168.100.98 10.42.0.0/16}"
+
+# Emit "<path> host1(opts) host2(opts) ..." for one export line.
+export_line() {
+    local path="$1" opts="$2" spec=""
+    for host in $NFS_ALLOWED; do
+        spec="${spec} ${host}(${opts})"
+    done
+    echo "${path}${spec}"
+}
+
+# Update exports file with more secure options (restricted clients + squash)
+SQUASH="rw,sync,no_subtree_check,all_squash,anonuid=65534,anongid=65534"
+{
+    echo "# Restricted to the k3s node + pod CIDR (was '*'). Clients: ${NFS_ALLOWED}"
+    export_line /data                "rw,sync,no_subtree_check,no_root_squash"
+    export_line /data/prometheus     "$SQUASH"
+    export_line /data/grafana        "$SQUASH"
+    export_line /data/alertmanager-0 "$SQUASH"
+    export_line /data/alertmanager-1 "$SQUASH"
+} > /etc/exports
 
 # Re-export NFS shares
 exportfs -ra

--- a/scripts/common/setup-nfs-server.sh
+++ b/scripts/common/setup-nfs-server.sh
@@ -51,19 +51,34 @@ echo -e "${GREEN}✓ Permissions configured${NC}"
 # Step 4: Configure NFS exports
 echo -e "\n${YELLOW}[4/8] Configuring NFS exports...${NC}"
 
-cat > /etc/exports <<'EOF'
-# Kubernetes NFS Exports
-# Main data directory for NFS provisioner (dynamic PVC creation)
-/data *(rw,sync,no_subtree_check,no_root_squash)
+# Allowed NFS clients. These exports were previously "*" (ANY host): because
+# no_root_squash is set, any device on the LAN — every phone/laptop on the WiFi —
+# could mount /data and read/write every file as root (all Prometheus/Grafana/
+# Loki/Tempo PV data and media). NFS is only consumed in-cluster, so restrict to
+# the k3s node itself and the pod CIDR. Override for a multi-node cluster, e.g.
+#   NFS_ALLOWED="192.168.100.98 10.42.0.0/16" sudo ./setup-nfs-server.sh
+NFS_ALLOWED="${NFS_ALLOWED:-192.168.100.98 10.42.0.0/16}"
+NFS_OPTS="rw,sync,no_subtree_check,no_root_squash"
 
-# Media directory for Plex
-/data/media *(rw,sync,no_subtree_check,no_root_squash)
+# Expand the client list into "host1(opts) host2(opts) ..." for one export line.
+nfs_clients() {
+    local spec=""
+    for host in $NFS_ALLOWED; do
+        spec="${spec} ${host}(${NFS_OPTS})"
+    done
+    echo "${spec# }"
+}
 
-# Plex config directory
-/data/plex *(rw,sync,no_subtree_check,no_root_squash)
-EOF
+{
+    echo "# Kubernetes NFS Exports"
+    echo "# Restricted to the k3s node + pod CIDR (was '*' — any LAN host)."
+    echo "# Clients: ${NFS_ALLOWED}"
+    echo "/data $(nfs_clients)"          # NFS provisioner (dynamic PVC creation)
+    echo "/data/media $(nfs_clients)"    # Media directory
+    echo "/data/plex $(nfs_clients)"     # Plex config directory
+} > /etc/exports
 
-echo -e "${GREEN}✓ Exports configured${NC}"
+echo -e "${GREEN}✓ Exports configured (clients: ${NFS_ALLOWED})${NC}"
 
 # Step 5: Apply NFS exports
 echo -e "\n${YELLOW}[5/8] Applying NFS exports...${NC}"
@@ -79,11 +94,15 @@ echo -e "${GREEN}✓ NFS server started${NC}"
 # Step 7: Configure firewall (if active)
 echo -e "\n${YELLOW}[7/8] Checking firewall configuration...${NC}"
 if command -v ufw &>/dev/null && ufw status | grep -q 'active'; then
-    echo -e "${YELLOW}Firewall is active, opening NFS ports...${NC}"
-    ufw allow from 192.168.100.0/24 to any port nfs
-    ufw allow from 192.168.100.0/24 to any port 111
-    ufw allow from 192.168.100.0/24 to any port 2049
-    echo -e "${GREEN}✓ Firewall configured${NC}"
+    echo -e "${YELLOW}Firewall is active, opening NFS ports to allowed clients only...${NC}"
+    # Was 192.168.100.0/24 (the whole LAN). NFS is node-local, so scope the
+    # firewall to the same clients as the exports. Node-to-itself traffic goes
+    # over loopback (ufw allows lo by default), so the node still mounts fine.
+    for client in $NFS_ALLOWED; do
+        ufw allow from "$client" to any port 111 proto tcp
+        ufw allow from "$client" to any port 2049 proto tcp
+    done
+    echo -e "${GREEN}✓ Firewall configured (clients: ${NFS_ALLOWED})${NC}"
 else
     echo -e "${BLUE}ℹ Firewall not active or ufw not installed${NC}"
 fi


### PR DESCRIPTION
## Context

The 2026-07-18 network scan confirmed the highest-severity finding: `/data`, `/data/media` and `/data/plex` are exported to `*` with `no_root_squash` and reachable on the LAN. From an ordinary WiFi host, `showmount -e 192.168.100.98` succeeds — and because of `no_root_squash`, **any device on the network could mount `/data` and read/write every file as root** (all Prometheus/Grafana/Loki/Tempo PV data and the media library). The intended ufw `/24` scope doesn't help: WiFi clients *are* on that subnet.

## Change

NFS is only consumed in-cluster (kubelet mounts on the node), so this scopes the exports **and** the ufw rules to the k3s node IP + pod CIDR via a configurable `NFS_ALLOWED` (default `192.168.100.98 10.42.0.0/16`):

- `scripts/common/setup-nfs-server.sh` — exports + ufw rules now iterate `NFS_ALLOWED` instead of `*` / `192.168.100.0/24`.
- `scripts/common/secure-nfs.sh` — same restriction, preserving the per-subdir `all_squash` options.

Node-to-itself NFS traffic traverses loopback (ufw allows `lo` by default), so in-cluster storage is unaffected.

## Applying (out-of-band — NFS is not Flux-managed)

On the node (`192.168.100.98`):
```bash
sudo ./scripts/common/setup-nfs-server.sh   # or secure-nfs.sh for the squash variant
```

## Verification

```bash
# On the node — new export list should show the node/pod CIDR, not *:
showmount -e localhost

# From another LAN host (e.g. the workstation) — should now be REFUSED/empty:
showmount -e 192.168.100.98

# In-cluster storage still works — force a PV write and confirm no read-only errors:
kubectl -n monitoring rollout restart statefulset prometheus-prometheus-stack-prometheus
kubectl -n monitoring get pods -w
flux get helmrelease -A   # all Ready, no NFS mount errors
```

Rollback: revert `/etc/exports` (git revert this branch + re-run the script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)