### PR TITLE
security(netpol): default-deny + scoped allow for the media namespace

### DIFF
--- a/k8s/core/security/media-network-policies.yaml
+++ b/k8s/core/security/media-network-policies.yaml
@@ -1,0 +1,63 @@
+# Default-deny + scoped-allow for the media namespace.
+#
+# Why: Jellyfin runs privileged (for /dev/dri QSV transcoding) in a namespace
+# that previously had NO NetworkPolicy — a container escape would have had
+# unrestricted pod-to-pod and egress reach across the cluster. Since the pod
+# stays privileged (de-privileging risks breaking hardware transcoding on this
+# single node), the network layer is the mitigation that contains it.
+#
+# Mirrors the proven monitoring/allow-grafana pattern: ingress is reached
+# through the hostNetwork ingress-nginx DaemonSet, so a namespaceSelector for
+# ingress-nginx matches it (its pod IP == the node IP). The explicit ipBlock for
+# the node IP is belt-and-suspenders for that same hostNetwork source.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: media
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-jellyfin
+  namespace: media
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: jellyfin
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Web UI / API reached through the ingress-nginx controller (hostNetwork, so
+  # its source is the node IP — both selectors below cover it).
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+    - ipBlock:
+        cidr: 192.168.100.98/32
+    ports:
+    - protocol: TCP
+      port: 8096
+  egress:
+  # DNS — resolve metadata providers and in-cluster names (CoreDNS in kube-system).
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 53
+  # Outbound HTTPS/HTTP for metadata + artwork (TheMovieDB, image CDNs) and the
+  # plugin catalog. No `to` selector = any destination on these ports only.
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 80


### PR DESCRIPTION
## Context

The 2026-07-18 network scan confirmed finding #3: the `media` namespace has **no NetworkPolicy**, and Jellyfin runs `privileged: true` (for `/dev/dri` QSV transcoding). A container escape there would have had unrestricted pod-to-pod and egress reach across the whole cluster.

De-privileging the pod was deliberately **skipped** — on this single node it risks breaking hardware transcoding (the device-cgroup allowlist, not file perms, is what `privileged` bypasses). So the network layer is the mitigation that contains the still-privileged pod.

## Change

New `k8s/core/security/media-network-policies.yaml` (Flux auto-includes it — no `kustomization.yaml` in that dir):

- **`default-deny-all`** in `media` (Ingress + Egress).
- **`allow-jellyfin`**:
  - Ingress on `8096` from `ingress-nginx` — mirrors the proven `monitoring/allow-grafana` pattern (the hostNetwork nginx controller's pod IP == the node IP), plus an explicit `ipBlock: 192.168.100.98/32` for that same source.
  - Egress limited to DNS (53) + outbound `443`/`80` for metadata/artwork (TheMovieDB, image CDNs, plugin catalog).

Validated with `kubectl apply --dry-run=client`; the `app.kubernetes.io/name: jellyfin` selector matches the running pod.

## Verification (after merge + Flux sync)

```bash
kubectl get netpol -n media                       # default-deny-all + allow-jellyfin
# Jellyfin still reachable through the ingress:
curl -sI -H 'Host: jellyfin.192.168.100.98.nip.io' http://192.168.100.98/ | head -1   # expect 302
# Metadata egress still works: open a movie in the UI, confirm artwork/metadata loads.
```

**Known trade-off:** if you use Jellyfin **DLNA** (LAN SSDP discovery) rather than the ingress host, default-deny will block it — say so and I'll add a DLNA allow rule. Rollback: `git revert` this branch (Flux removes the policies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)